### PR TITLE
Make `install.sh` handle more edge cases

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -62,6 +62,12 @@ install_latest_release() {
     binary=$(find latest_release_dir -type f -executable | head -n 1)
 
     if [ -z "$binary" ]; then
+      first=$(find latest_release_dir -type f | head -n 1)
+      chmod +x "$first"
+      binary=$(find latest_release_dir -type f -executable | head -n 1)
+    fi
+
+    if [ -z "$binary" ]; then
       echo "No binary file found in the release archive."
       exit 1
     fi

--- a/install.sh
+++ b/install.sh
@@ -72,6 +72,15 @@ install_latest_release() {
       exit 1
     fi
 
+    if [[ "$binary" == *"$variant"* ]]; then
+      original=$binary
+      binary="${binary//$variant/}"
+      binary="${binary%-}"
+      mv "$original" "$binary"
+      chmod +x "$binary"
+      echo "Renamed $(basename "$original") to $(basename "$binary")"
+    fi
+
     echo "Installing $binary to $install_dir..."
     mkdir -p "$install_dir"
     sudo cp "$binary" "$install_dir"


### PR DESCRIPTION
Account for archives that don't have correct permissions set, and that have have the binaries suffixed